### PR TITLE
add atmos vendor test helpers

### DIFF
--- a/pkg/atmos/format.go
+++ b/pkg/atmos/format.go
@@ -85,22 +85,6 @@ func FormatAtmosTerraformArgs(options *Options, args ...string) []string {
 		terraformArgs = append(terraformArgs, FormatTerraformPlanFileAsArg(commandType, options.PlanFilePath)...)
 	}
 
-	if commandType == "vendor" && options.VendorComponent != "" {
-		terraformArgs = append(terraformArgs, "--component", options.VendorComponent)
-	}
-
-	if commandType == "vendor" && options.VendorStack != "" {
-		terraformArgs = append(terraformArgs, "--stack", options.VendorStack)
-	}
-
-	if commandType == "vendor" && len(options.VendorTags) > 0 {
-		terraformArgs = append(terraformArgs, "--tags", strings.Join(options.VendorTags, ","))
-	}
-
-	if commandType == "vendor" && options.VendorType != "" {
-		terraformArgs = append(terraformArgs, "--type", options.VendorType)
-	}
-
 	return terraformArgs
 }
 

--- a/pkg/atmos/options.go
+++ b/pkg/atmos/options.go
@@ -74,6 +74,10 @@ type Options struct {
 	PluginDir                 string                 // The path of downloaded plugins to pass to the atmos init command (-plugin-dir)
 	SetVarsAfterVarFiles      bool                   // Pass -var options after -var-file options to Atmos commands
 	WarningsAsErrors          map[string]string      // Terraform warning messages that should be treated as errors. The keys are a regexp to match against the warning and the value is what to display to a user if that warning is matched.
+	VendorComponent           string                 // The component to pass to the atmos vendor command, if not passed all components will be vendored
+	VendorStack               string                 // The stack to pass to the atmos vendor command, if not passed all stacks will be vendored
+	VendorTags                []string               // The tags to pass to the atmos vendor command, if not passed all tags will be vendored
+	VendorType                string                 // The type of vendor to pass to the atmos vendor command, if not passed `terraform` will be used
 }
 
 // Clone makes a deep copy of most fields on the Options object and returns it.

--- a/pkg/atmos/vendor_pull.go
+++ b/pkg/atmos/vendor_pull.go
@@ -12,7 +12,7 @@ func VendorPull(t testing.TestingT, options *Options) string {
 	return out
 }
 
-// ApplyE runs atmos vendor with the given options and return stdout/stderr.
+// VendorPullE runs atmos vendor with the given options and return stdout/stderr.
 func VendorPullE(t testing.TestingT, options *Options) (string, error) {
 	return RunAtmosCommandE(t, options, FormatArgs(options, "vendor", "pull")...)
 }

--- a/pkg/atmos/vendor_pull.go
+++ b/pkg/atmos/vendor_pull.go
@@ -1,0 +1,18 @@
+package atmos
+
+import (
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// Vendor runs atmos vendor with the given options and return stdout/stderr.
+func VendorPull(t testing.TestingT, options *Options) string {
+	out, err := VendorPullE(t, options)
+	require.NoError(t, err)
+	return out
+}
+
+// ApplyE runs atmos vendor with the given options and return stdout/stderr.
+func VendorPullE(t testing.TestingT, options *Options) (string, error) {
+	return RunAtmosCommandE(t, options, FormatArgs(options, "vendor", "pull")...)
+}

--- a/pkg/atmos/vendor_pull_test.go
+++ b/pkg/atmos/vendor_pull_test.go
@@ -1,0 +1,82 @@
+package atmos
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVendorPullBasic(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp(atmosExamplePath, t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(testFolder)
+
+	fmt.Printf("running in %s\n", testFolder)
+
+	options := WithDefaultRetryableErrors(t, &Options{
+		AtmosBasePath: testFolder,
+	})
+
+	_, err = VendorPullE(t, options)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(testFolder, "components", "terraform", "vpc"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(testFolder, "components", "terraform", "vpc-flow-logs-bucket"))
+	require.NoError(t, err)
+}
+
+func TestVendorPullSingleComponent(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp(atmosExamplePath, t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(testFolder)
+
+	fmt.Printf("running in %s\n", testFolder)
+
+	options := WithDefaultRetryableErrors(t, &Options{
+		AtmosBasePath:   testFolder,
+		VendorComponent: "vpc",
+	})
+
+	_, err = VendorPullE(t, options)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(testFolder, "components", "terraform", "vpc"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(testFolder, "components", "terraform", "vpc-flow-logs-bucket"))
+	require.Error(t, err)
+}
+
+func TestVendorPullByTag(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp(atmosExamplePath, t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(testFolder)
+
+	fmt.Printf("running in %s\n", testFolder)
+
+	options := WithDefaultRetryableErrors(t, &Options{
+		AtmosBasePath: testFolder,
+		VendorTags:    []string{"storage"},
+	})
+
+	_, err = VendorPullE(t, options)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(testFolder, "components", "terraform", "vpc"))
+	require.Error(t, err)
+
+	_, err = os.Stat(filepath.Join(testFolder, "components", "terraform", "vpc-flow-logs-bucket"))
+	require.NoError(t, err)
+}

--- a/pkg/atmos/vendor_pull_test.go
+++ b/pkg/atmos/vendor_pull_test.go
@@ -10,12 +10,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func setupVendorTest(t *testing.T) (string, func()) {
+	testFolder, err := files.CopyTerraformFolderToTemp(atmosExamplePath, t.Name())
+	require.NoError(t, err, "Failed to copy Terraform folder to temp directory")
+
+	cleanup := func() {
+		os.RemoveAll(testFolder)
+	}
+
+	return testFolder, cleanup
+}
+
 func TestVendorPullBasic(t *testing.T) {
 	t.Parallel()
 
-	testFolder, err := files.CopyTerraformFolderToTemp(atmosExamplePath, t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(testFolder)
+	testFolder, cleanup := setupVendorTest(t)
+	defer cleanup()
 
 	fmt.Printf("running in %s\n", testFolder)
 
@@ -23,7 +33,7 @@ func TestVendorPullBasic(t *testing.T) {
 		AtmosBasePath: testFolder,
 	})
 
-	_, err = VendorPullE(t, options)
+	_, err := VendorPullE(t, options)
 	require.NoError(t, err)
 
 	_, err = os.Stat(filepath.Join(testFolder, "components", "terraform", "vpc"))
@@ -36,9 +46,8 @@ func TestVendorPullBasic(t *testing.T) {
 func TestVendorPullSingleComponent(t *testing.T) {
 	t.Parallel()
 
-	testFolder, err := files.CopyTerraformFolderToTemp(atmosExamplePath, t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(testFolder)
+	testFolder, cleanup := setupVendorTest(t)
+	defer cleanup()
 
 	fmt.Printf("running in %s\n", testFolder)
 
@@ -47,7 +56,7 @@ func TestVendorPullSingleComponent(t *testing.T) {
 		VendorComponent: "vpc",
 	})
 
-	_, err = VendorPullE(t, options)
+	_, err := VendorPullE(t, options)
 	require.NoError(t, err)
 
 	_, err = os.Stat(filepath.Join(testFolder, "components", "terraform", "vpc"))
@@ -60,9 +69,8 @@ func TestVendorPullSingleComponent(t *testing.T) {
 func TestVendorPullByTag(t *testing.T) {
 	t.Parallel()
 
-	testFolder, err := files.CopyTerraformFolderToTemp(atmosExamplePath, t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(testFolder)
+	testFolder, cleanup := setupVendorTest(t)
+	defer cleanup()
 
 	fmt.Printf("running in %s\n", testFolder)
 
@@ -71,7 +79,7 @@ func TestVendorPullByTag(t *testing.T) {
 		VendorTags:    []string{"storage"},
 	})
 
-	_, err = VendorPullE(t, options)
+	_, err := VendorPullE(t, options)
 	require.NoError(t, err)
 
 	_, err = os.Stat(filepath.Join(testFolder, "components", "terraform", "vpc"))

--- a/test/fixtures/atmos/vendor.yaml
+++ b/test/fixtures/atmos/vendor.yaml
@@ -1,0 +1,32 @@
+apiVersion: atmos/v1
+kind: AtmosVendorConfig
+metadata:
+  name: test-vendor-config
+  description: Atmos vendoring manifest for testing
+spec:
+  # `imports` or `sources` (or both) must be defined in a vendoring manifest
+  imports: []
+
+  sources:
+    - component: "vpc"
+      source: "github.com/cloudposse/terraform-aws-components.git//modules/vpc?ref={{.Version}}"
+      version: "1.398.0"
+      targets:
+        - "components/terraform/vpc"
+      included_paths:
+        - "**/*.tf"
+      excluded_paths:
+        - "**/providers.tf"
+      tags:
+        - networking
+    - component: "vpc-flow-logs-bucket"
+      source: "github.com/cloudposse/terraform-aws-components.git//modules/vpc-flow-logs-bucket?ref={{.Version}}"
+      version: "1.398.0"
+      targets:
+        - "components/terraform/vpc-flow-logs-bucket"
+      included_paths:
+        - "**/*.tf"
+      excluded_paths:
+        - "**/providers.tf"
+      tags:
+        - storage


### PR DESCRIPTION
## what

Add `atmos vendor` test helpers

## why

To allow `atmos vendor` to be called from within component tests to vendor in dependent components.